### PR TITLE
Add verification for folder/file permissions

### DIFF
--- a/global.ps1
+++ b/global.ps1
@@ -1,14 +1,44 @@
 ﻿$logLocation = "%userprofile%\AppData\LocalLow\miHoYo\Genshin Impact\output_log.txt";
 $LogLocationChina = "%userprofile%\AppData\LocalLow\miHoYo\$([char]0x539f)$([char]0x795e)\output_log.txt";
-$path = [System.Environment]::ExpandEnvironmentVariables($logLocation);
-if (-Not [System.IO.File]::Exists($path)) {
-    $path = [System.Environment]::ExpandEnvironmentVariables($LogLocationChina);
-    if (-Not [System.IO.File]::Exists($path)) {
+
+function tryTestPath($p){
+    try {
+        $test = Test-Path -Path $p -ErrorAction Stop
+        return $test
+    }
+    catch {
+        if ($_ -like "*Access is denied*") {
+            Write-Host "No permission to open file, try running PowerShell with Administrator rights." -ForegroundColor Red
+            return "denied"
+        }
+    }
+}
+
+$path = [System.Environment]::ExpandEnvironmentVariables($logLocation)
+$test = tryTestPath($path)
+if ($test -match "denied") { return; }
+if ($test -ne $true) {
+
+    $path = [System.Environment]::ExpandEnvironmentVariables($LogLocationChina)
+    $test = tryTestPath($path)
+    if ($test -match "denied") { return }
+    if ($test -ne $true) {
+
         Write-Host "We cannot find the log file! Make sure to open the wish history ingame first!" -ForegroundColor Red
         return
     }
 }
-$logs = Get-Content -Path $path
+
+try {
+    $logs = Get-Content -Path $path -ErrorAction Stop
+}
+catch {
+    if ($_ -like "*is denied.*") {
+        Write-Host "No permission to open file, try running PowerShell with Administrator rights." -ForegroundColor Red
+        return
+    }
+}
+
 $match = $logs -match "^OnGetWebViewPageFinish.*log$"
 if (-Not $match) {
     Write-Host "We cannot find the wish history url! Make sure to open the wish history ingame first!" -ForegroundColor Red


### PR DESCRIPTION
Some users on Genshin Wishes discord had problems with permissions, and the script was returning that the file was not found, this should avoid some confusion about this again.

I did some tests and its seems to be working, but its a good idea to test again before merging this PR.